### PR TITLE
Possibility to define the set of worksheets to include

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,15 @@ _([go to the definition in the code](./src/main/kotlin/com/tailoredapps/gradle/l
 #### Product-dependent configuration
 _([go to the definition in the code](./src/main/kotlin/com/tailoredapps/gradle/localize/extensions/ProductLocalizeExtension.kt))_
 
-| Field                              | Type           | Description |
-| :--------------------------------- | :------------- | ----------- |
-| `serviceAccountCredentialsFile`    | `String`       | The local path to the credentials file for the service-account. More about this in [Google Drive Service Account Credentials](#google-drive-service-account-credentials). Optional, if set in the base configuration |
-| `sheetId`                          | `String`       | The id of the spreadsheet which contains the localization entries. You can get this id from the link to your spreadsheet. e.g. For the spreadsheet-link `https://docs.google.com/spreadsheets/d/1fwRj1ZFPu2XlrDqkaqmIpJulqR5OVFEZnN35a9v37yc/edit`, the `sheetId` is `1fwRj1ZFPu2XlrDqkaqmIpJulqR5OVFEZnN35a9v37yc`.  |
-| `languageTitles`                   | `List<String>` | The list of column titles of the languages in the localization sheet (which is simultaneously also the list of local language folders which are created, so those should be e.g. `de` for german or `en` for english, and the column titles in the sheet should be named the same. |
-| `baseLanguage` (default: `en`)     | `String`       | The language (one of the values from `languageTitles`) which should be the default language, which is placed in the `values` folder (so if this is set to `en`, there will be no `values-en` folder created, but the english localizations will be placed in the `values` folder). |
-| `localizationPath` (default: `./src/main/res`) | `String` | The base directory path to put the localizations in. This defaults to `./src/main/res`, which is the default path within an app module to put the string resources to. Change this if you want to have your localizations put somewhere else. |
-| `addComments`                      | `Boolean`      | Whether the comments from the spreadsheet should be added to the strings.xml files (as comments) as well. Defaults to the value of the base configuration if not set |
+| Field                                          | Type           | Description |
+| :--------------------------------------------- | :------------- | ----------- |
+| `serviceAccountCredentialsFile`                | `String`       | The local path to the credentials file for the service-account. More about this in [Google Drive Service Account Credentials](#google-drive-service-account-credentials). Optional, if set in the base configuration |
+| `sheetId`                                      | `String`       | The id of the spreadsheet which contains the localization entries. You can get this id from the link to your spreadsheet. e.g. For the spreadsheet-link `https://docs.google.com/spreadsheets/d/1fwRj1ZFPu2XlrDqkaqmIpJulqR5OVFEZnN35a9v37yc/edit`, the `sheetId` is `1fwRj1ZFPu2XlrDqkaqmIpJulqR5OVFEZnN35a9v37yc`.  |
+| `worksheets`                                   | `List<String>` | The titles of the worksheets ("tabs") of the spreadsheet which should be considered as source for localization entries. If not set, all worksheets will be parsed. |
+| `languageTitles`                               | `List<String>` | The list of column titles of the languages in the localization sheet (which is simultaneously also the list of local language folders which are created, so those should be e.g. `de` for german or `en` for english, and the column titles in the sheet should be named the same. |
+| `baseLanguage` (default: `en`)                 | `String`       | The language (one of the values from `languageTitles`) which should be the default language, which is placed in the `values` folder (so if this is set to `en`, there will be no `values-en` folder created, but the english localizations will be placed in the `values` folder). |
+| `localizationPath` (default: `./src/main/res`) | `String`       | The base directory path to put the localizations in. This defaults to `./src/main/res`, which is the default path within an app module to put the string resources to. Change this if you want to have your localizations put somewhere else. |
+| `addComments`                                  | `Boolean`      | Whether the comments from the spreadsheet should be added to the strings.xml files (as comments) as well. Defaults to the value of the base configuration if not set |
 
 
 

--- a/src/main/kotlin/com/tailoredapps/gradle/localize/LocalizationConfig.kt
+++ b/src/main/kotlin/com/tailoredapps/gradle/localize/LocalizationConfig.kt
@@ -6,6 +6,7 @@ data class LocalizationConfig(
     val productName: String,
     val serviceAccountCredentialsFile: File,
     val sheetId: String,
+    val worksheets: List<String>?,
     val languageTitles: List<String>,
     val baseLanguage: String,
     val localizationPath: File,

--- a/src/main/kotlin/com/tailoredapps/gradle/localize/Localize.kt
+++ b/src/main/kotlin/com/tailoredapps/gradle/localize/Localize.kt
@@ -22,6 +22,7 @@ class Localize {
         )
         val parsedSheet = localizationSheetParser.parseSheet(
             sheet = sheet,
+            worksheets = config.worksheets,
             languageColumnTitles = config.languageTitles
         )
 
@@ -50,6 +51,7 @@ class Localize {
         )
         val parsedSheet = localizationSheetParser.parseSheet(
             sheet = sheet,
+            worksheets = config.worksheets,
             languageColumnTitles = config.languageTitles
         )
 

--- a/src/main/kotlin/com/tailoredapps/gradle/localize/extension/ExtensionMerger.kt
+++ b/src/main/kotlin/com/tailoredapps/gradle/localize/extension/ExtensionMerger.kt
@@ -23,6 +23,7 @@ class ExtensionMerger(
                 serviceAccountCredentialsPath
             ),
             sheetId = productConfig.sheetId,
+            worksheets = productConfig.worksheets?.toList(),
             languageTitles = productConfig.languageTitles,
             baseLanguage = productConfig.baseLanguage ?: baseConfig.baseLanguage,
             localizationPath = pathToFileManager.pathToFile(localizationPath),

--- a/src/main/kotlin/com/tailoredapps/gradle/localize/extension/ProductLocalizeExtension.kt
+++ b/src/main/kotlin/com/tailoredapps/gradle/localize/extension/ProductLocalizeExtension.kt
@@ -20,15 +20,19 @@ open class ProductLocalizeExtension(
     /**
      * The id of the spreadsheet which contains the localization entries.
      * You can get this id from the link to your spreadsheet.
-     * @see [BaseLocalizeExtension.sheetId]
      */
     var sheetId: String = ""
+
+    /**
+     * The titles worksheets (_tabs_) to parse / take into consideration as source for strings.
+     * If not set, all tabs of the sheet will be considered.
+     */
+    var worksheets: MutableList<String>? = null
 
     /**
      * The list of column titles of the languages in the localization sheet (which is simultaneously
      * also the list of local language folders which are created, so those should be e.g. `de` for german or `en` for
      * english, and the column titles in the sheet should be named the same.
-     * @see [BaseLocalizeExtension.languageTitles]
      */
     var languageTitles: MutableList<String> = mutableListOf()
 
@@ -46,7 +50,6 @@ open class ProductLocalizeExtension(
      *
      * As this here is the flavor dependent config, you might want to use this here to set the target of the given
      * localizations to e.g. `./src/<myFlavorName>/res`.
-     * @see [BaseLocalizeExtension.localizationPath]
      */
     var localizationPath: String = DEFAULT_LOCALIZATION_PATH
 

--- a/src/test/kotlin/com/tailoredapps/gradle/localize/extension/ExtensionMergerTest.kt
+++ b/src/test/kotlin/com/tailoredapps/gradle/localize/extension/ExtensionMergerTest.kt
@@ -53,6 +53,7 @@ class ExtensionMergerTest {
             productName = "mock",
             serviceAccountCredentialsFile = File("/tmp/./some-service-accounts-file.json"),
             sheetId = "ASDF1234!",
+            worksheets = null,
             languageTitles = listOf("de", "en", "ru"),
             baseLanguage = "ru",
             localizationPath = File("/tmp", "./src/main/some-custom-res"),
@@ -66,6 +67,7 @@ class ExtensionMergerTest {
         val mockProductFlavor = ProductLocalizeExtension("someProductName").apply {
             serviceAccountCredentialsFile = "./some-service-accounts-file-for-mock.json"
             sheetId = "SHEET_FOR_MOCK"
+            worksheets = mutableListOf("firstTab", "secondTab", "thirdTab")
             languageTitles = mutableListOf("de", "en", "ru", "it")
             baseLanguage = "it"
             localizationPath = "./src/main/some-custom-res-for-mock"
@@ -90,6 +92,7 @@ class ExtensionMergerTest {
             productName = "someProductName",
             serviceAccountCredentialsFile = File("/tmp/./some-service-accounts-file-for-mock.json"),
             sheetId = "SHEET_FOR_MOCK",
+            worksheets = listOf("firstTab", "secondTab", "thirdTab"),
             languageTitles = listOf("de", "en", "ru", "it"),
             baseLanguage = "it",
             localizationPath = File("/tmp", "./src/main/some-custom-res-for-mock"),


### PR DESCRIPTION
Fixes #5.

Adds the possibility to define the set of worksheets ("tabs") to include:

```
localizeConfig {
    serviceAccountCredentialsFile = "../google_drive_credentials.json"
    configuration {
        main {
            sheetId = "<sheetId>
            languageTitles = ["de", "en"]
            worksheets = ["Main", "Feature1"]
        }
    }
}
```