### PR TITLE
Fix empty trailing languages will result in an IndexOutOfBoundsException

### DIFF
--- a/src/main/kotlin/com/tailoredapps/gradle/localize/localization/LocalizationSheetParser.kt
+++ b/src/main/kotlin/com/tailoredapps/gradle/localize/localization/LocalizationSheetParser.kt
@@ -80,11 +80,14 @@ class LocalizationSheetParser {
      * @param sheet The [DriveManager.Sheet] to parse
      * @param worksheets The list of tabs ("worksheets") to parse / return.
      * If `null`, all tabs will be taken,
-     * Otherwise (non-null): all tabs named as one of the items in [tabs] will be parsed and returned
+     * Otherwise (non-null): all tabs named as one of the items in [tabs] will be parsed and
+     * returned.
      * @param languageColumnTitles The sheet column titles for the localization to parse
      *
-     * @return A [ParsedSheet] object which contains all localization entries found in the given [sheet] for the given
-     * [languageColumnTitles].
+     * @return A [ParsedSheet] object which contains all localization entries found in the given
+     * [sheet] for the given [languageColumnTitles]. This will for all entries contain map entries
+     * for all languages & identifiers, but the values may be null if they are not set in the
+     * worksheet.
      */
     fun parseSheet(
         sheet: DriveManager.Sheet,
@@ -138,11 +141,15 @@ class LocalizationSheetParser {
                             ParsedSheet.LocalizationEntry(
                                 identifier = Platform.values()
                                     .mapNotNull { platform ->
-                                        indexOfPlatforms[platform]?.let { index -> platform to row[index] }
+                                        indexOfPlatforms[platform]?.let { index ->
+                                            platform to row.getOrNull(index)
+                                        }
                                     }
                                     .toMap(),
                                 values = indexOfLanguages
-                                    .map { (languageIdentifier, columnIndex) -> languageIdentifier to row[columnIndex] }
+                                    .map { (languageIdentifier, columnIndex) ->
+                                        languageIdentifier to row.getOrNull(columnIndex)
+                                    }
                                     .toMap(),
                                 comment = indexOfComment?.let { index -> row.getOrNull(index) }
                             )

--- a/src/test/kotlin/com/tailoredapps/gradle/localize/localization/LocalizationSheetParserTest.kt
+++ b/src/test/kotlin/com/tailoredapps/gradle/localize/localization/LocalizationSheetParserTest.kt
@@ -1,0 +1,194 @@
+package com.tailoredapps.gradle.localize.localization
+
+import com.tailoredapps.gradle.localize.drive.DriveManager
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.Before
+import org.junit.Test
+
+
+class LocalizationSheetParserTest {
+
+    private lateinit var localizationSheetParser: LocalizationSheetParser
+
+    @Before
+    fun setUp() {
+        localizationSheetParser = LocalizationSheetParser()
+    }
+
+    @Test
+    fun lastLanguageDoesNotContainAValue() {
+        val sheet = DriveManager.Sheet(
+            id = "some-id",
+            worksheets = listOf(
+                DriveManager.Sheet.WorkSheet(
+                    title = "First Worksheet",
+                    cells = listOf(
+                        listOf(
+                            "Identifier iOS",
+                            "Identifier Android",
+                            "de",
+                            "en",
+                            "fr",
+                            "Kommentar"
+                        ),
+                        listOf("//This is a comment in the worksheet"),
+                        listOf(
+                            null,
+                            "key1",
+                            "German Translation",
+                            "English Translation",
+                            "French Translation",
+                            "And also a comment"
+                        ),
+                        listOf(
+                            null,
+                            "key2",
+                            "German Translation",
+                            "English Translation",
+                            "French Translation"
+                        ),
+                        listOf(
+                            null,
+                            "key3",
+                            "German Translation",
+                            "English Translation",
+                            "French Translation",
+                            null
+                        ),
+                        listOf(
+                            null,
+                            "key4",
+                            "German Translation",
+                            "English Translation",
+                            null,
+                            "And also a comment"
+                        ),
+                        listOf(
+                            null,
+                            "key5",
+                            "German Translation",
+                            null,
+                            "French Translation",
+                            "And also a comment"
+                        ),
+                        listOf(
+                            null,
+                            "key6",
+                            "German Translation",
+                            "English Translation",
+                            null
+                        ),
+                        listOf(null, "key7", "German Translation", "English Translation")
+                    )
+                )
+            )
+        )
+        val parsedSheet = localizationSheetParser.parseSheet(
+            sheet = sheet,
+            worksheets = null,
+            languageColumnTitles = listOf("de", "en", "fr")
+        )
+
+        parsedSheet.worksheets.size shouldBeEqualTo 1
+        val parsedWorksheet = parsedSheet.worksheets.first()
+        parsedWorksheet.title shouldBeEqualTo "First Worksheet"
+        parsedWorksheet.entries.size shouldBeEqualTo 7
+
+        parsedWorksheet.entries[0].also { entry ->
+            entry.identifier shouldBeEqualTo mapOf(
+                LocalizationSheetParser.Platform.iOS to null,
+                LocalizationSheetParser.Platform.Android to "key1"
+            )
+            entry.values shouldBeEqualTo mapOf(
+                "de" to "German Translation",
+                "en" to "English Translation",
+                "fr" to "French Translation"
+            )
+            entry.comment.shouldNotBeNull()
+            entry.comment shouldBeEqualTo "And also a comment"
+        }
+
+        parsedWorksheet.entries[1].also { entry ->
+            entry.identifier shouldBeEqualTo mapOf(
+                LocalizationSheetParser.Platform.iOS to null,
+                LocalizationSheetParser.Platform.Android to "key2"
+            )
+            entry.values shouldBeEqualTo mapOf(
+                "de" to "German Translation",
+                "en" to "English Translation",
+                "fr" to "French Translation"
+            )
+            entry.comment.shouldBeNull()
+        }
+
+        parsedWorksheet.entries[2].also { entry ->
+            entry.identifier shouldBeEqualTo mapOf(
+                LocalizationSheetParser.Platform.iOS to null,
+                LocalizationSheetParser.Platform.Android to "key3"
+            )
+            entry.values shouldBeEqualTo mapOf(
+                "de" to "German Translation",
+                "en" to "English Translation",
+                "fr" to "French Translation"
+            )
+            entry.comment.shouldBeNull()
+        }
+
+        parsedWorksheet.entries[3].also { entry ->
+            entry.identifier shouldBeEqualTo mapOf(
+                LocalizationSheetParser.Platform.iOS to null,
+                LocalizationSheetParser.Platform.Android to "key4"
+            )
+            entry.values shouldBeEqualTo mapOf(
+                "de" to "German Translation",
+                "en" to "English Translation",
+                "fr" to null
+            )
+            entry.comment.shouldNotBeNull()
+            entry.comment shouldBeEqualTo "And also a comment"
+        }
+
+        parsedWorksheet.entries[4].also { entry ->
+            entry.identifier shouldBeEqualTo mapOf(
+                LocalizationSheetParser.Platform.iOS to null,
+                LocalizationSheetParser.Platform.Android to "key5"
+            )
+            entry.values shouldBeEqualTo mapOf(
+                "de" to "German Translation",
+                "en" to null,
+                "fr" to  "French Translation"
+            )
+            entry.comment.shouldNotBeNull()
+            entry.comment shouldBeEqualTo "And also a comment"
+        }
+
+        parsedWorksheet.entries[5].also { entry ->
+            entry.identifier shouldBeEqualTo mapOf(
+                LocalizationSheetParser.Platform.iOS to null,
+                LocalizationSheetParser.Platform.Android to "key6"
+            )
+            entry.values shouldBeEqualTo mapOf(
+                "de" to "German Translation",
+                "en" to "English Translation",
+                "fr" to  null
+            )
+            entry.comment.shouldBeNull()
+        }
+
+        parsedWorksheet.entries[6].also { entry ->
+            entry.identifier shouldBeEqualTo mapOf(
+                LocalizationSheetParser.Platform.iOS to null,
+                LocalizationSheetParser.Platform.Android to "key7"
+            )
+            entry.values shouldBeEqualTo mapOf(
+                "de" to "German Translation",
+                "en" to "English Translation",
+                "fr" to  null
+            )
+            entry.comment.shouldBeNull()
+        }
+    }
+
+}


### PR DESCRIPTION
When trailing languages in the sheet do not have a value associated with them, an `IndexOutOfBoundsException` will be thrown instead of those languages containing a `null` as value.