### PR TITLE
Adds overload for method which requires groovy closure

### DIFF
--- a/src/main/kotlin/com/tailoredapps/gradle/localize/extension/BaseLocalizeExtension.kt
+++ b/src/main/kotlin/com/tailoredapps/gradle/localize/extension/BaseLocalizeExtension.kt
@@ -31,5 +31,14 @@ open class BaseLocalizeExtension(
         productConfigContainer.configure(closure)
     }
 
+    /**
+     * Adds a flavor specific config which may overwrite any config of the base config (except [addToCheckTask]).
+     *
+     * @see ProductLocalizeExtension
+     */
+    fun configuration(action: NamedDomainObjectContainer<ProductLocalizeExtension>.() -> Unit) {
+        action.invoke(productConfigContainer)
+    }
+
     internal lateinit var productConfigContainer: NamedDomainObjectContainer<ProductLocalizeExtension>
 }


### PR DESCRIPTION
Cannot create groovy closure from kotlin buildscripts, therefore add an overload.

Desired output:

```kotlin

localizeConfig {
    serviceAccountCredentialsFile = "./google_drive_credentials.json" 
    configuration {
        create("main") {
            sheetId = "abc" 
            languageTitles = listOf("de", "en") 
        }
    })
}

```